### PR TITLE
feat: NeoVim support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This plugin connects Vim to [vivify Markdown
 viewer](https://github.com/jannis-baum/vivify).
 
+NeoVim is supported.
+
 ## Features
 
 - all open viewers automatically update their content as you are editing it in Vim

--- a/autoload/vivify.vim
+++ b/autoload/vivify.vim
@@ -1,7 +1,13 @@
 let s:viv_url = 'http://localhost:' . ($VIV_PORT == '' ? '31622' : $VIV_PORT)
 
+if has("nvim")
+    let s:job_start = function("jobstart")
+else
+    let s:job_start = function("job_start")
+endif
+
 function! s:post(data)
-    call job_start([
+    call s:job_start([
         \ 'curl', '-X', 'POST', '-H', 'Content-type: application/json',
         \ '--data', json_encode(a:data),
         \ s:viv_url . '/viewer' . expand('%:p')
@@ -17,7 +23,7 @@ function! vivify#sync_cursor()
 endfunction
 
 function! vivify#open()
-    call job_start(
+    call s:job_start(
         \ ['viv', expand('%:p')],
         \ {"in_io": "null", "out_io": "null", "err_io": "null"}
     \)

--- a/autoload/vivify.vim
+++ b/autoload/vivify.vim
@@ -1,5 +1,7 @@
 let s:viv_url = 'http://localhost:' . ($VIV_PORT == '' ? '31622' : $VIV_PORT)
 
+" Note: nvim's jobstart isn't exactly a drop-in replacement for vim's job_start
+" See here: https://stackoverflow.com/questions/74999614/difference-between-vims-job-start-function-and-neovims-jobstart-functi
 if has("nvim")
     let s:job_start = function("jobstart")
 else
@@ -23,6 +25,7 @@ function! vivify#sync_cursor()
 endfunction
 
 function! vivify#open()
+    " Note: nvim's jobstart doesn't use these opt keys
     call s:job_start(
         \ ['viv', expand('%:p')],
         \ {"in_io": "null", "out_io": "null", "err_io": "null"}


### PR DESCRIPTION
Related issue: https://github.com/jannis-baum/vivify.vim/issues/3

I have tried this in both NeoVim and Vim and everything seems to work.

There's a caveat here though, because nvim's `jobstart` is not exactly a drop-in replacement for vim's `job_start`, as far as I understand mainly in the `opt` flags they use.

This answer on StackOverflow is helpful on this: https://stackoverflow.com/questions/74999614/difference-between-vims-job-start-function-and-neovims-jobstart-functi

So in a way the fact that I can just alias a different function for nvim and vim and it works can be seen as a coincidence and not a guarantee, but the usage here is simple and I'm pointing this out as a *possible future problem* :smile: 