### PR TITLE
Add initial vim help doc

### DIFF
--- a/doc/vivify.txt
+++ b/doc/vivify.txt
@@ -15,16 +15,16 @@ You may also want to map it to a keybind, for example: >
     nnoremap <leader>v <cmd>Vivify<cr>
 <
 Tip: to set a keybind for Markdown files only, add the mapping in your
-ftplugin directory under markdown.vim as: >
+|ftplugin| directory under markdown.vim as: >
     nnoremap <buffer> <leader>v <cmd>Vivify<cr>
 <
 
 CONFIGURATION     *vivify-configuration*
 
-Refresh page contents on TextChanged and TextChangedI (default): >
+Refresh page contents on |TextChanged| and |TextChangedI| (default): >
     let g:vivify_instant_refresh = 1
 <
-Refresh page contents on CursorHold and CursorHoldI: >
+Refresh page contents on |CursorHold| and |CursorHoldI|: >
     let g:vivify_instant_refresh = 0
 <
 To recognize other filetypes as markdown, use g:vivify_filetypes array,

--- a/doc/vivify.txt
+++ b/doc/vivify.txt
@@ -1,0 +1,46 @@
+*vivify.txt*        Markdown preview on the browser
+
+
+INTRODUCTION      *vivify*
+
+Connects (Neo)Vim to the Vivify Markdown preview tool.
+View and live-sync Markdown files while editing.
+
+
+USAGE             *vivify-usage*
+
+Use the command :Vivify to open the current buffer in the browser.
+
+You may also want to map it to a keybind, for example: >
+    nnoremap <leader>v <cmd>Vivify<cr>
+<
+Tip: to set a keybind for Markdown files only, add the mapping in your
+ftplugin directory under markdown.vim as: >
+    nnoremap <buffer> <leader>v <cmd>Vivify<cr>
+<
+
+CONFIGURATION     *vivify-configuration*
+
+Refresh page contents on TextChanged and TextChangedI (default): >
+    let g:vivify_instant_refresh = 1
+<
+Refresh page contents on CursorHold and CursorHoldI: >
+    let g:vivify_instant_refresh = 0
+<
+To recognize other filetypes as markdown, use g:vivify_filetypes array,
+for example: >
+    let g:vivify_filetypes = ['vimwiki']
+<
+
+CONTRIBUTING      *vivify-contributing*
+
+Bug reports, feature requests and questions welcome!
+
+For this plugin:
+    https://github.com/jannis-baum/vivify.vim
+
+For Vivify:
+    https://github.com/jannis-baum/Vivify
+
+
+vim:tw=78:sw=4:ts=8:ft=help:norl:


### PR DESCRIPTION
Close #9 

How's this for an initial document?

![image](https://github.com/user-attachments/assets/1758bfac-d0a6-4929-866d-e94c8cb4ca77)

Of course, the `g:vivify_instant_refresh` bit depends on how we decide on #10, but it can be adjusted.