### PR TITLE
Percent encode paths

### DIFF
--- a/autoload/vivify.vim
+++ b/autoload/vivify.vim
@@ -2,8 +2,8 @@ let s:viv_url = 'http://localhost:' . ($VIV_PORT == '' ? '31622' : $VIV_PORT)
 
 " Note: nvim's jobstart isn't exactly a drop-in replacement for vim's job_start
 " See here: https://stackoverflow.com/questions/74999614/difference-between-vims-job-start-function-and-neovims-jobstart-functi
-if has("nvim")
-    let s:job_start = function("jobstart")
+if has('nvim')
+    let s:job_start = function('jobstart')
 
     " job is job_id as returned from jobstart()
     function! s:stdin_send_and_close(job, data)
@@ -18,7 +18,7 @@ else
         call ch_close_in(l:channel)
     endfunction
 
-    let s:job_start = function("job_start")
+    let s:job_start = function('job_start')
 endif
 
 function! s:post(data)
@@ -44,6 +44,6 @@ function! vivify#open()
     " Note: nvim's jobstart doesn't use these opt keys
     call s:job_start(
         \ ['viv', expand('%:p')->substitute(':', '\\:', 'g') . ':' . getpos('.')[1]],
-        \ {"in_io": "null", "out_io": "null", "err_io": "null"}
+        \ {'in_io': 'null', 'out_io': 'null', 'err_io': 'null'}
     \)
 endfunction

--- a/autoload/vivify.vim
+++ b/autoload/vivify.vim
@@ -24,7 +24,7 @@ endif
 function! s:percent_encode(path)
     if has('python3')
         " With python3 support, do proper percent encoding of url
-        " Vim needs to be compiled with +python
+        " Vim needs to be compiled with +python3 (check `vim --version`)
         " Neovim needs pynvim installed
         py3 from urllib.parse import quote
         return py3eval('quote("' . a:path . '")')

--- a/autoload/vivify.vim
+++ b/autoload/vivify.vim
@@ -21,13 +21,27 @@ else
     let s:job_start = function('job_start')
 endif
 
+function! s:percent_encode(path)
+    if has('python3')
+        " With python3 support, do proper percent encoding of url
+        " Vim needs to be compiled with +python
+        " Neovim needs pynvim installed
+        py3 from urllib.parse import quote
+        return py3eval('quote("' . a:path . '")')
+    else
+        " If no python3 support, still handle the biggest problem
+        " which is spaces in filenames
+        return substitute(a:path, ' ', '%20', 'g')
+    endif
+endfunction
+
 function! s:post(data)
     let l:job = s:job_start([
         \ 'curl',
         \ '-X', 'POST',
         \ '-H', 'Content-type: application/json',
         \ '--data', '@-',
-        \ s:viv_url . '/viewer' . expand('%:p')
+        \ s:viv_url . '/viewer' . s:percent_encode(expand('%:p'))
     \])
     call s:stdin_send_and_close(l:job, json_encode(a:data))
 endfunction


### PR DESCRIPTION
Close #20

The primary intention is to fix the case where filenames have spaces in
them and this plugin doesn't encode the URL properly so it appears as if
vivify can't refresh

We do this whether (n)vim has python3 support or not, but with python3
support do a proper encoding with a library to handle more esoteric
cases, for example curly brackets in filenames.

We found that even without the library, characters such as ä, á, ñ, €
already work, so it's probably a very rare case where you need any more
meticulous encoding for filenames. And then even if that occurs,
enabling python3 support will solve it :)


