### PR TITLE
docs: fix incorrect spelling of Neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This plugin connects Vim to [vivify Markdown
 viewer](https://github.com/jannis-baum/vivify).
 
-NeoVim is supported.
+Neovim is supported.
 
 ## Features
 


### PR DESCRIPTION
Inspired by justinmk's tweet on 𝕏

https://x.com/justinmk/status/1895462261499817988 ([archive](https://archive.ph/oiv2a))

"NeoVim" is not correct :)