### PR TITLE
Allow runtime option changes to affect viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ This plugin connects Vim and Neovim to the live markdown viewer
     - refresh page contents on `TextChanged` and `TextChangedI` (default)
 - `g:vivify_instant_refresh = 0`
     - refresh page contents on `CursorHold` and `CursorHoldI`
+- `g:vivify_auto_scroll = 1`
+    - enable viewer auto-scroll (default)
+- `g:vivify_auto_scroll = 0`
+    - disable viewer auto-scroll
 - `g:vivify_filetypes`
     - additional filetypes to recognize as markdown
     - for example `let g:vivify_filetypes = ['vimwiki']`

--- a/doc/vivify.txt
+++ b/doc/vivify.txt
@@ -27,6 +27,12 @@ Refresh page contents on |TextChanged| and |TextChangedI| (default): >
 Refresh page contents on |CursorHold| and |CursorHoldI|: >
     let g:vivify_instant_refresh = 0
 <
+Enable viewer auto-scroll (default): >
+    let g:vivify_auto_scroll = 1
+<
+Disable viewer auto-scroll: >
+    let g:vivify_auto_scroll = 0
+<
 To recognize other filetypes as markdown, use g:vivify_filetypes array,
 for example: >
     let g:vivify_filetypes = ['vimwiki']

--- a/plugin/vivify.vim
+++ b/plugin/vivify.vim
@@ -3,9 +3,6 @@ if exists("g:loaded_vivify")
 endif
 let g:loaded_vivify = 1
 
-let s:vivify_instant_refresh = get(g:, "vivify_instant_refresh", 1)
-let s:vivify_auto_scroll = get(g:, "vivify_auto_scroll", 1)
-
 let s:filetype_match_str = 'markdown'
 if exists("g:vivify_filetypes")
     call add(g:vivify_filetypes, s:filetype_match_str)
@@ -19,17 +16,18 @@ endfunction
 function! s:init()
     augroup vivify_sync
         autocmd!
-        if s:vivify_instant_refresh
-            autocmd TextChanged,TextChangedI *
-                \ if s:is_vivify_filetype(&filetype) | call vivify#sync_content() | endif
-        else
-            autocmd CursorHold,CursorHoldI *
-                \ if s:is_vivify_filetype(&filetype) | call vivify#sync_content() | endif
-        endif
-        if s:vivify_auto_scroll
-            autocmd CursorMoved,CursorMovedI *
-                \ if s:is_vivify_filetype(&filetype) | call vivify#sync_cursor() | endif
-        endif
+        autocmd TextChanged,TextChangedI *
+            \ if get(g:, "vivify_instant_refresh", 1) && s:is_vivify_filetype(&filetype) |
+            \     call vivify#sync_content() |
+            \ endif
+        autocmd CursorHold,CursorHoldI *
+            \ if !get(g:, "vivify_instant_refresh", 1) && s:is_vivify_filetype(&filetype) |
+            \     call vivify#sync_content() |
+            \ endif
+        autocmd CursorMoved,CursorMovedI *
+            \ if get(g:, "vivify_auto_scroll", 1) && s:is_vivify_filetype(&filetype) |
+            \     call vivify#sync_cursor() |
+            \ endif
     augroup END
 endfunction
 

--- a/plugin/vivify.vim
+++ b/plugin/vivify.vim
@@ -4,6 +4,7 @@ endif
 let g:loaded_vivify = 1
 
 let s:vivify_instant_refresh = get(g:, "vivify_instant_refresh", 1)
+let s:vivify_auto_scroll = get(g:, "vivify_auto_scroll", 1)
 
 let s:filetype_match_str = 'markdown'
 if exists("g:vivify_filetypes")
@@ -25,8 +26,10 @@ function! s:init()
             autocmd CursorHold,CursorHoldI *
                 \ if s:is_vivify_filetype(&filetype) | call vivify#sync_content() | endif
         endif
-        autocmd CursorMoved,CursorMovedI *
-            \ if s:is_vivify_filetype(&filetype) | call vivify#sync_cursor() | endif
+        if s:vivify_auto_scroll
+            autocmd CursorMoved,CursorMovedI *
+                \ if s:is_vivify_filetype(&filetype) | call vivify#sync_cursor() | endif
+        endif
     augroup END
 endfunction
 


### PR DESCRIPTION
Resolves #33

Need to merge #32 first

For example, doing `:let g:vivify_auto_scroll = 0` can disable auto-scroll for the currently open viewer, rather than only at init.

Todo: did I need to consider `g:vivify_filetypes` too or does that perhaps already work that way?