### PR TITLE
Updated README.md. The plugins is available on nixpkgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ can install this plugin just like any other Vim plugin, e.g.
 - with Lazy: `{ "jannis-baum/vivify.vim" }`
 - ...
 
-The plugin is available in [nixpkgs-unstable](https://search.nixos.org/packages?channel=unstable&query=vivify-vim) as `vimPlugins.vivify-vim`. You can add it with HomeManager with by adding it to:
+The plugin is available in [nixpkgs-unstable](https://search.nixos.org/packages?channel=unstable&query=vivify-vim) as `vimPlugins.vivify-vim`. You can add it with HomeManager by adding it to:
 
 - `programs.vim.plugins` (for Vim)
 - `programs.neovim.plugins` (for Neovim)

--- a/README.md
+++ b/README.md
@@ -40,3 +40,8 @@ can install this plugin just like any other Vim plugin, e.g.
 - with Plug: `Plug jannis-baum/vivify.vim`
 - with Lazy: `{ "jannis-baum/vivify.vim" }`
 - ...
+
+The plugin is available in [nixpkgs-unstable](https://search.nixos.org/packages?channel=unstable&query=vivify-vim) as `vimPlugins.vivify-vim`. You can add it with HomeManager with by adding it to:
+
+- `programs.vim.plugins` (for Vim)
+- `programs.neovim.plugins` (for Neovim)


### PR DESCRIPTION
The plugin is finally on [nixpkgs](https://search.nixos.org/packages?channel=unstable&query=vivify-vim). There was some problem with Nix's building process and it took longer than I expected.
It's only on the unstable branch for the moment. Nixpkgs' next release (26.05) will probably contain it.

Vim plugins in nixpkgs don't have maintainers. It's mostly autogenerated updates. But I will keep an eye on this nixpkgs. 